### PR TITLE
don't output the test key/value when not in test mode

### DIFF
--- a/views/helpers/paypal.php
+++ b/views/helpers/paypal.php
@@ -196,6 +196,9 @@ class PaypalHelper extends AppHelper {
 
 		if ($encryptedFields === false) {
 			foreach ($options as $name => $value) {
+				if ($name == 'test' && !$value) {
+					continue;
+				}
 				$retval .= $this->__hiddenNameValue($name, $value);
 			}
 		} else {


### PR DESCRIPTION
Just a minor change, shouldn't affect real-world use.