### PR TITLE
Modify PayPal IPN listener to return required HTTP 200 OK status to PayPal.

### DIFF
--- a/Controller/InstantPaymentNotificationsController.php
+++ b/Controller/InstantPaymentNotificationsController.php
@@ -48,7 +48,7 @@ class InstantPaymentNotificationsController extends PaypalIpnAppController {
 		} else {
 			$this->log('POST Not Validated', 'paypal');
 		}
-		return $this->redirect('/');
+		return CURLOPT_HTTP200ALIASES;
 	}
 
 /**


### PR DESCRIPTION
- Modified return at end of InstantPaymentNotificationController::process method.

Co-authored-by: Camasoft <carolyn@camasoft.net>